### PR TITLE
working gz input without conversion

### DIFF
--- a/tools/krakentools/extract_kraken_reads.xml
+++ b/tools/krakentools/extract_kraken_reads.xml
@@ -19,8 +19,8 @@
 
             ## tool needs a file ending with gz to work
             #if $full_ext.endswith("gz"):
-                cp $temp_input_1 'temp_input_1.gz' &&
-                cp $temp_input_2 'temp_input_2.gz' &&
+                ln -s $temp_input_1 'temp_input_1.gz' &&
+                ln -s $temp_input_2 'temp_input_2.gz' &&
                 #set temp_input_1 = 'temp_input_1.gz'
                 #set temp_input_2 = 'temp_input_2.gz'
             #end if 
@@ -32,8 +32,8 @@
 
             ## tool needs a file ending with gz to work
             #if $full_ext2.endswith("gz"):
-                cp $temp_input_1 'temp_input_1.gz' &&
-                cp $temp_input_2 'temp_input_2.gz' &&
+                ln -s $temp_input_1 'temp_input_1.gz' &&
+                ln -s $temp_input_2 'temp_input_2.gz' &&
                 #set temp_input_1 = 'temp_input_1.gz'
                 #set temp_input_2 = 'temp_input_2.gz'
             #end if 
@@ -45,7 +45,7 @@
 
             ## tool needs a file ending with gz to work
             #if $full_ext3.endswith("gz"):
-                cp $temp_input_1 'temp_input_1.gz' &&
+                ln -s $temp_input_1 'temp_input_1.gz' && 
                 #set temp_input_1 = 'temp_input_1.gz'
             #end if 
 

--- a/tools/krakentools/extract_kraken_reads.xml
+++ b/tools/krakentools/extract_kraken_reads.xml
@@ -16,35 +16,41 @@
             #set full_ext = $library.input_1.datatype.file_ext
             #set temp_input_1 = $library.input_1
             #set temp_input_2 = $library.input_2
-            #if $full_ext.endswith("gz")
-                gunzip $temp_input_1
-                && 
-                gunzip $temp_input_2
-                &&
-            #end if
-            #set input_1 = $temp_input_1
-            #set input_2 = $temp_input_2
+
+            ## tool needs a file ending with gz to work
+            #if $full_ext.endswith("gz"):
+                cp $temp_input_1 'temp_input_1.gz' &&
+                cp $temp_input_2 'temp_input_2.gz' &&
+                #set temp_input_1 = 'temp_input_1.gz'
+                #set temp_input_2 = 'temp_input_2.gz'
+            #end if 
+
         #else if $library.type == 'paired_collection'
             #set full_ext2 = $library.input_1.forward.datatype.file_ext
             #set temp_input_1 = $library.input_1.forward
             #set temp_input_2 = $library.input_1.reverse
-            #if $full_ext2.endswith("gz")
-                gunzip $temp_input_1
-                && 
-                gunzip $temp_input_2
-                &&
-            #end if
-            #set input_1 = $temp_input_1
-            #set input_2 = $temp_input_2
+
+            ## tool needs a file ending with gz to work
+            #if $full_ext2.endswith("gz"):
+                cp $temp_input_1 'temp_input_1.gz' &&
+                cp $temp_input_2 'temp_input_2.gz' &&
+                #set temp_input_1 = 'temp_input_1.gz'
+                #set temp_input_2 = 'temp_input_2.gz'
+            #end if 
+
+
         #else
             #set full_ext3 = $library.input_1.datatype.file_ext
             #set temp_input_1 = $library.input_1
-            #if $full_ext3.endswith("gz")
-                gunzip $temp_input_1
-                &&
-            #end if
-            #set input_1 = $temp_input_1
+
+            ## tool needs a file ending with gz to work
+            #if $full_ext3.endswith("gz"):
+                cp $temp_input_1 'temp_input_1.gz' &&
+                #set temp_input_1 = 'temp_input_1.gz'
+            #end if 
+
         #end if
+
         ## name output according to --fastq_output param
         ## tests fails if file does not have correct ending
         #if str($fastq_output) == '':
@@ -57,7 +63,7 @@
         ## do not quote $taxid
         extract_kraken_reads.py
         -k '$results'
-        -s '$input_1'
+        -s '$temp_input_1'
         -o '$temp_output_1'
         --taxid $taxid
         --max '$max'
@@ -67,7 +73,7 @@
         $fastq_output
 
         #if str( $library.type ) != "single":
-        -s2 '$input_2'
+        -s2 '$temp_input_2'
         -o2 '$temp_output_2'
         #end if
         #if $include_parents or $include_children:
@@ -159,7 +165,7 @@
             <param name="taxid" value="11176" />
             <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz"  />
         </test>        
-        <!-- test Kraken2 input, single input -->
+        <!-- test Kraken2 input, single input, zipped -->
         <test expect_num_outputs="1">
             <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
             <param name="library|type" value="single" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Actually the tool wrapper does not need to unzip the files since `extract_kraken_reads.py` can work with gzipped files, it only needs files ending with .gz to know what to do.